### PR TITLE
Fix dashboard response rendering

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -605,7 +605,7 @@ export default function DashboardPage() {
                                 </div>
                               ) : (
                                 <p className="bg-white border rounded-lg px-3 py-2 text-sm">
-                                  "{response.response_text || "응답 없음"}"
+                                  {response.response_text || "응답 없음"}
                                 </p>
                               )}
                             </div>


### PR DESCRIPTION
## Summary
- fix string literal bug when showing open text answers in dashboard

## Testing
- `npx next lint` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68404e9161c08324bb5a3ee7b6738021