### PR TITLE
Fix response trend axis calculation

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -877,25 +877,24 @@ export default function DashboardPage() {
                           ...responseTrendData.map((d) => d.count),
                           1
                         );
-                        const step = Math.ceil(maxCount / 4);
                         const yLabels = Array.from(
                           { length: 5 },
-                          (_, i) => i * step
+                          (_, i) => Math.round((maxCount * i) / 4)
                         );
 
                         return yLabels.map((value) => (
                           <g key={value}>
                             <line
                               x1="30"
-                              y1={`${100 - (value / (step * 4)) * 100}%`}
+                              y1={`${100 - (value / maxCount) * 100}%`}
                               x2="100%"
-                              y2={`${100 - (value / (step * 4)) * 100}%`}
+                              y2={`${100 - (value / maxCount) * 100}%`}
                               stroke="#e5e7eb"
                               strokeDasharray="2,2"
                             />
                             <text
                               x="25"
-                              y={`${100 - (value / (step * 4)) * 100}%`}
+                              y={`${100 - (value / maxCount) * 100}%`}
                               textAnchor="end"
                               className="text-xs"
                               fill="#6b7280"


### PR DESCRIPTION
## Summary
- correct Y-axis scale for response trend chart so max label matches data

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840702e388c8324af6fb4ec3295007e