### PR TITLE
Fix chart labels

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -676,7 +676,11 @@ export default function DashboardPage() {
                 <div className="space-y-4">
                   {/* 차트 영역 */}
                   <div className="h-48 relative">
-                    <svg className="w-full h-full overflow-visible">
+                    <svg
+                      className="w-full h-full overflow-visible"
+                      viewBox="0 0 100 100"
+                      preserveAspectRatio="none"
+                    >
                       <defs>
                         <linearGradient
                           id="revisitGradient"
@@ -703,22 +707,22 @@ export default function DashboardPage() {
                         <g key={value}>
                           <line
                             x1="30"
-                            y1={`${100 - value}%`}
-                            x2="100%"
-                            y2={`${100 - value}%`}
+                            y1={100 - value}
+                            x2="100"
+                            y2={100 - value}
                             stroke="#e5e7eb"
                             strokeDasharray="2,2"
                           />
-                          <text
-                            x="25"
-                            y={`${100 - value}%`}
-                            textAnchor="end"
-                            className="text-xs"
-                            fill="#6b7280"
-                            dominantBaseline="middle"
-                          >
-                            {value}%
-                          </text>
+                            <text
+                              x="25"
+                              y={100 - value}
+                              textAnchor="end"
+                              fontSize="3"
+                              fill="#6b7280"
+                              dominantBaseline="middle"
+                            >
+                              {value}%
+                            </text>
                         </g>
                       ))}
 
@@ -730,11 +734,11 @@ export default function DashboardPage() {
                               const x =
                                 30 +
                                 (index / (revisitTrendData.length - 1)) * 70;
-                              const y = `${100 - data.percentage}%`;
+                              const y = 100 - data.percentage;
                               if (index === 0) return `M ${x} ${y}`;
                               return `L ${x} ${y}`;
                             })
-                            .join(" ") + ` L ${100} 100% L 30 100% Z`
+                            .join(" ") + ` L 100 100 L 30 100 Z`
                         }
                         fill="url(#revisitGradient)"
                       />
@@ -746,7 +750,7 @@ export default function DashboardPage() {
                             const x =
                               30 + (index / (revisitTrendData.length - 1)) * 70;
                             const y = 100 - data.percentage;
-                            return `${x},${y}%`;
+                            return `${x},${y}`;
                           })
                           .join(" ")}
                         fill="none"
@@ -758,7 +762,7 @@ export default function DashboardPage() {
                       {revisitTrendData.map((data, index) => {
                         const x =
                           30 + (index / (revisitTrendData.length - 1)) * 70;
-                        const y = `${100 - data.percentage}%`;
+                        const y = 100 - data.percentage;
                         return (
                           <g key={index}>
                             <circle
@@ -775,7 +779,7 @@ export default function DashboardPage() {
                                 y={y}
                                 dy="-10"
                                 textAnchor="middle"
-                                className="text-xs font-medium"
+                                fontSize="3"
                                 fill="#3b82f6"
                               >
                                 {data.percentage}%
@@ -790,9 +794,9 @@ export default function DashboardPage() {
                         <text
                           key={index}
                           x={30 + (index / (revisitTrendData.length - 1)) * 70}
-                          y="95%"
+                          y={95}
                           textAnchor="middle"
-                          className="text-xs"
+                          fontSize="3"
                           fill="#6b7280"
                         >
                           {data.date}
@@ -849,7 +853,11 @@ export default function DashboardPage() {
                 <div className="space-y-4">
                   {/* 차트 영역 */}
                   <div className="h-48 relative">
-                    <svg className="w-full h-full overflow-visible">
+                    <svg
+                      className="w-full h-full overflow-visible"
+                      viewBox="0 0 100 100"
+                      preserveAspectRatio="none"
+                    >
                       <defs>
                         <linearGradient
                           id="responseGradient"
@@ -886,22 +894,22 @@ export default function DashboardPage() {
                           <g key={value}>
                             <line
                               x1="30"
-                              y1={`${100 - (value / maxCount) * 100}%`}
-                              x2="100%"
-                              y2={`${100 - (value / maxCount) * 100}%`}
+                              y1={100 - (value / maxCount) * 100}
+                              x2="100"
+                              y2={100 - (value / maxCount) * 100}
                               stroke="#e5e7eb"
                               strokeDasharray="2,2"
                             />
-                            <text
-                              x="25"
-                              y={`${100 - (value / maxCount) * 100}%`}
-                              textAnchor="end"
-                              className="text-xs"
-                              fill="#6b7280"
-                              dominantBaseline="middle"
-                            >
-                              {value}
-                            </text>
+                              <text
+                                x="25"
+                                y={100 - (value / maxCount) * 100}
+                                textAnchor="end"
+                                fontSize="3"
+                                fill="#6b7280"
+                                dominantBaseline="middle"
+                              >
+                                {value}
+                              </text>
                           </g>
                         ));
                       })()}
@@ -919,10 +927,10 @@ export default function DashboardPage() {
                                 30 +
                                 (index / (responseTrendData.length - 1)) * 70;
                               const y = 100 - (data.count / maxCount) * 100;
-                              if (index === 0) return `M ${x} ${y}%`;
-                              return `L ${x} ${y}%`;
+                              if (index === 0) return `M ${x} ${y}`;
+                              return `L ${x} ${y}`;
                             })
-                            .join(" ") + ` L ${100} 100% L 30 100% Z`
+                            .join(" ") + ` L 100 100 L 30 100 Z`
                         }
                         fill="url(#responseGradient)"
                       />
@@ -939,7 +947,7 @@ export default function DashboardPage() {
                               30 +
                               (index / (responseTrendData.length - 1)) * 70;
                             const y = 100 - (data.count / maxCount) * 100;
-                            return `${x},${y}%`;
+                            return `${x},${y}`;
                           })
                           .join(" ")}
                         fill="none"
@@ -955,7 +963,7 @@ export default function DashboardPage() {
                         );
                         const x =
                           30 + (index / (responseTrendData.length - 1)) * 70;
-                        const y = `${100 - (data.count / maxCount) * 100}%`;
+                        const y = 100 - (data.count / maxCount) * 100;
                         return (
                           <g key={index}>
                             <circle
@@ -972,7 +980,7 @@ export default function DashboardPage() {
                                 y={y}
                                 dy="-10"
                                 textAnchor="middle"
-                                className="text-xs font-medium"
+                                fontSize="3"
                                 fill="#10b981"
                               >
                                 {data.count}
@@ -987,9 +995,9 @@ export default function DashboardPage() {
                         <text
                           key={index}
                           x={30 + (index / (responseTrendData.length - 1)) * 70}
-                          y="95%"
+                          y={95}
                           textAnchor="middle"
-                          className="text-xs"
+                          fontSize="3"
                           fill="#6b7280"
                         >
                           {data.date}


### PR DESCRIPTION
## Summary
- make dashboard chart labels smaller so they no longer overlap

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68407934bb408324bbc0a78eae9edafe